### PR TITLE
Fix RDKit wasm path

### DIFF
--- a/src/rdkit.ts
+++ b/src/rdkit.ts
@@ -14,7 +14,9 @@ export function loadRDKit(): Promise<RDKitModule> {
     return Promise.resolve((window as any).RDKit as RDKitModule);
   }
   if (!initPromise) {
-    initPromise = initRDKitModule().then((instance: RDKitModule) => {
+    initPromise = initRDKitModule({
+      locateFile: () => `${process.env.PUBLIC_URL || ''}/static/js/RDKit_minimal.wasm`,
+    }).then((instance: RDKitModule) => {
       (window as any).RDKit = instance;
       console.log('RDKit version:', instance.version());
       return instance;


### PR DESCRIPTION
## Summary
- configure RDKit loader to resolve the WASM file using `locateFile`

## Testing
- `CI=true npm test -- --passWithNoTests --silent`

------
https://chatgpt.com/codex/tasks/task_e_68579035d0788323818a0abd601f9ba1